### PR TITLE
Flip the array of passwords before turning it into a collection

### DIFF
--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -29,8 +29,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
     public function boot()
     {
         $path = realpath(__DIR__.'/../resources/config/passwordlist.txt');
-        $dumbPasswords = collect(explode("\n", file_get_contents($path)));
-        $data = $dumbPasswords->flip();
+        $data = collect(array_flip(explode("\n", file_get_contents($path))));
 
         Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) use ($data) {
             return !$data->has($value);


### PR DESCRIPTION
If flipped after it's been made into a collection, then 2 collections exist in memory, and with 10k items, that consumes a lot of memory. Instead, this performs the flip before it puts into a collection.

Fixes #10 

I'll also look into caching the array in a separate PR