### PR TITLE
Remove the flip altogether

### DIFF
--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -29,7 +29,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
     public function boot()
     {
         $path = realpath(__DIR__.'/../resources/config/passwordlist.txt');
-        $dumbPasswords = collect(explode("\n", file_get_contents($path)));
+        $data = collect(explode("\n", file_get_contents($path)));
 
         Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) use ($data) {
             return !$data->contains($value);

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -30,10 +30,9 @@ class DumbPasswordServiceProvider extends ServiceProvider
     {
         $path = realpath(__DIR__.'/../resources/config/passwordlist.txt');
         $dumbPasswords = collect(explode("\n", file_get_contents($path)));
-        $data = $dumbPasswords->flip();
 
         Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) use ($data) {
-            return !$data->has($value);
+            return !$data->contains($value);
         }, $this->message);
     }
 


### PR DESCRIPTION
An alternative solution to #11 would be to get rid of the flip altogether and just use `contains` instead of `has`. This is probably even more efficient.

Fixes #10