### PR TITLE
Add caching + defer the service provider

### DIFF
--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -22,7 +22,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
     * @var bool
     */
     protected $defer = true;
-    
+
     /**
      * Default error message.
      *

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -36,7 +36,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-         Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) {
+        Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) {
             $path = realpath(__DIR__ . '/../resources/config/passwordlist.txt');
             $cache_key = md5_file($path);
             $data = Cache::rememberForever('dumbpwd_list_' . $cache_key, function () use ($path) {

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -35,12 +35,13 @@ class DumbPasswordServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        $path = realpath(__DIR__.'/../resources/config/passwordlist.txt');
-        $dumbPasswords = collect(explode("\n", file_get_contents($path)));
-        $data = $dumbPasswords->flip();
-
-        Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) use ($data) {
-            return !$data->has($value);
+         Validator::extend('dumbpwd', function ($attribute, $value, $parameters, $validator) {
+            $path = realpath(__DIR__ . '/../resources/config/passwordlist.txt');
+            $cache_key = md5_file($path);
+            $data = Cache::rememberForever('dumbpwd_list_' . $cache_key, function () use ($path) {
+                return collect(explode("\n", file_get_contents($path)));
+            });
+            return !$data->contains($value);
         }, $this->message);
     }
 

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -16,6 +16,13 @@ use Validator;
 
 class DumbPasswordServiceProvider extends ServiceProvider
 {
+    /*
+    * Indicates if loading of the provider is deferred.
+    *
+    * @var bool
+    */
+    protected $defer = true;
+    
     /**
      * Default error message.
      *

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -12,6 +12,7 @@
 namespace Unicodeveloper\DumbPassword;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Cache;
 use Validator;
 
 class DumbPasswordServiceProvider extends ServiceProvider


### PR DESCRIPTION
This builds upon #12 to further improve the performance of this service provider:

* Moves the reading of the file to inside the validator's definition. That way the file isn't read if the validator isn't used during a request
* Defer's the service provider's loading until it's needed
* Adds caching using `rememberForever` and an md5 hash of the file as the key, so that the file doesn't need to be re-read and re-computed every time.

Let me know what you think 👍 