### PR TITLE
Switch back to a non-defered service provider

### DIFF
--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -22,7 +22,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
     *
     * @var bool
     */
-    protected $defer = true;
+    protected $defer = false;
 
     /**
      * Default error message.


### PR DESCRIPTION
Hey, me again 👋 

Unfortunately, I realized that having the service provider be deferred made the validation rules not load in time in some instances. This reverts that change.

Sorry for the trouble, unfortunately you'll have to cut another release 😦 