### PR TITLE
Make passwordlist check case insensitive

### DIFF
--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -40,9 +40,12 @@ class DumbPasswordServiceProvider extends ServiceProvider
             $path = realpath(__DIR__ . '/../resources/config/passwordlist.txt');
             $cache_key = md5_file($path);
             $data = Cache::rememberForever('dumbpwd_list_' . $cache_key, function () use ($path) {
-                return collect(explode("\n", file_get_contents($path)));
+                return collect(explode("\n", file_get_contents($path)))
+                    ->map(function ($password) {
+                            return strtolower($password);
+                    });
             });
-            return !$data->contains($value);
+            return !$data->contains(strtolower($value));
         }, $this->message);
     }
 
@@ -56,7 +59,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
 
     /**
      * Get the services provided by the provider.
-     * 
+     *
      * @return array
      */
     public function provides()

--- a/src/DumbPasswordServiceProvider.php
+++ b/src/DumbPasswordServiceProvider.php
@@ -59,7 +59,7 @@ class DumbPasswordServiceProvider extends ServiceProvider
 
     /**
      * Get the services provided by the provider.
-     *
+     * 
      * @return array
      */
     public function provides()


### PR DESCRIPTION
Make the password list and user provided password both lowercase, so bad passwords are always identified regardless of how many characters are capitalised